### PR TITLE
Some changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,8 +7,8 @@ teamspeak:
   home: "/srv/ts3"
   shell: "/usr/sbin/nologin"
   symlink: "current"
-  version: "3.3.0"
-  checksum: "sha256:f124868f7bdb1b359f984d2b5cd16b6e0259cecb85bad32ffafdfa91576065cb"
+  version: "3.4.0"
+  checksum: "sha256:7d6ec8e97d4a9e9913a7e01f2e7f5f9fddfdc41b11e668d013a0f4b574d1918b"
   keep: 3
 
 teamspeak_ini_enabled: no

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,16 +14,19 @@ teamspeak:
 teamspeak_ini_enabled: no
 teamspeak_ini_filename: ts3server.ini
 
+#by setting this to true you accept to license included with teamspeak
+teamspeak_accept_license: false
+
 teamspeak_use_license: no
 teamspeak_license_srcfile: files/licensekey.dat
-teamspeak_licensepath: 
+teamspeak_licensepath:
 
 teamspeak_network:
   voice:
     default_port: 9987
     ip: 0.0.0.0
   filetransfer:
-    port: 30033 
+    port: 30033
     ip: 0.0.0.0
   query:
     port: 10011

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,7 @@
     content: ""
     owner: "{{ teamspeak.user }}"
     group: "{{ teamspeak.user }}"
-  when: accept_teamspeak_license
+  when: teamspeak_accept_license
   notify:
     - Restart teamspeak server
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,6 +75,15 @@
   notify:
     - Restart teamspeak server
 
+- name: "Install : Accept license for TeamSpeak {{ teamspeak.version }} server"
+  copy:
+    dest: "{{ teamspeak.home }}/.ts3server_license_accepted"
+    content: ""
+    owner: "{{ teamspeak.user }}"
+    group: "{{ teamspeak.user }}"
+  notify:
+    - Restart teamspeak server
+
 - name: "Install systemd service file"
   template:
     src: teamspeak3-server.service.j2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -47,6 +47,17 @@
   notify:
     - Restart teamspeak server
 
+- name: "Configuration : Create TeamSpeak 3 database server configuration file"
+  template:
+    src: ts3db_mariadb.ini.j2
+    dest: "{{ teamspeak.home }}/ts3db_mariadb.ini"
+    mode: 0644
+    owner: "{{ teamspeak.user }}"
+    group: "{{ teamspeak.user }}"
+  notify:
+    - Restart teamspeak server
+  when: teamspeak_db.plugin == 'ts3db_mariadb'
+
 - name: "Ensure license directory exists"
   file:
     path: "{{ teamspeak_licensepath }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,6 +81,7 @@
     content: ""
     owner: "{{ teamspeak.user }}"
     group: "{{ teamspeak.user }}"
+  when: accept_teamspeak_license
   notify:
     - Restart teamspeak server
 

--- a/templates/ts3db_mariadb.ini.j2
+++ b/templates/ts3db_mariadb.ini.j2
@@ -1,0 +1,6 @@
+[config]
+host={{ teamspeak_db.host }}
+port={{ teamspeak_db.port }}
+username={{ teamspeak_db.username }}
+password={{ teamspeak_db.password }}
+database={{ teamspeak_db.database }}

--- a/templates/ts3server.ini.j2
+++ b/templates/ts3server.ini.j2
@@ -13,3 +13,11 @@ licensepath={{ teamspeak_licensepath }}/
 {% if teamspeak_machine_id is not none %}
 machine_id={{ teamspeak_machine_id }}
 {% endif %}
+
+{% if teamspeak_db.plugin == 'ts3db_mariadb' %}
+dbplugin={{ teamspeak_db.plugin }}
+dbpluginparameter=ts3db_mariadb.ini
+dbsqlpath=sql/
+dbsqlcreatepath=create_mysql/
+dbconnections=10
+{% endif %}

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -1,1 +1,1 @@
-systemd_service_file_path: "/lib/systemd/system/"
+systemd_service_file_path: "/etc/systemd/system/"


### PR DESCRIPTION
Was also keeping my own fork of original, now abandoned repo, so why not join forces. Nice job on simplifying role, btw.
Wanted to split it into individual PRs but looks like alot of work for nothing.

This PR:
1) Adds support for ts3db_mariadb, for keeping TS3 data in mysql
2) Auto-accepts TS3 license (https://support.teamspeakusa.com/index.php?/Knowledgebase/Article/View/344/16/how-to-accept-the-server-license-agreement-server--310)
3) Bumps install to 3.4.0
4) Corrects path for systemd units (/lib/systemd/system is for package-provided units, /etc/systemd/system should be used for non-packaged things)

Mariadb configuration example (i use host_vars for configuring my nodes in this example):
```
teamspeak_db:
  plugin: ts3db_mariadb
  host: 127.0.0.1
  port: 3306
  database: ts3_prod_db
  username: ts3_prod_user
  password: ts3_prod_password
```
If not specified, it should use good old sqlite.